### PR TITLE
Explicitly provide the $logger argument to the parent handler class

### DIFF
--- a/src/Scheduled/CartExpiryTaskHandler.php
+++ b/src/Scheduled/CartExpiryTaskHandler.php
@@ -42,7 +42,7 @@ class CartExpiryTaskHandler extends ScheduledTaskHandler
         LoyaltyEngageApiService $loyaltyEngageApiService,
         LoggerInterface $logger
     ) {
-        parent::__construct($scheduledTaskRepository);
+        parent::__construct($scheduledTaskRepository, $logger);
         $this->orderRepository = $orderRepository;
         $this->loyaltyEngageApiService = $loyaltyEngageApiService;
         $this->logger = $logger;
@@ -63,14 +63,14 @@ class CartExpiryTaskHandler extends ScheduledTaskHandler
     {
         $expiryTime = $this->loyaltyEngageApiService->getExpiryTime();
         $loggerStatus = $this->loyaltyEngageApiService->getLoggerStatus();
-        
+
         $fromTime = new \DateTime('now', new \DateTimezone('UTC'));
         $expiryMinutes = $expiryTime * 60;
         $fromTime->sub(new \DateInterval("PT{$expiryMinutes}S"));
         $fromDate = $fromTime->format('Y-m-d H:i:s');
 
         $context = Context::createDefaultContext();
-        
+
         $criteria = new Criteria();
         $criteria->addFilter(new RangeFilter('createdAt', [
             RangeFilter::LTE => $fromDate,

--- a/src/Scheduled/OrderPlaceTaskHandler.php
+++ b/src/Scheduled/OrderPlaceTaskHandler.php
@@ -41,7 +41,7 @@ class OrderPlaceTaskHandler extends ScheduledTaskHandler
         LoyaltyEngageApiService $loyaltyEngageApiService,
         LoggerInterface $logger
     ) {
-        parent::__construct($scheduledTaskRepository);
+        parent::__construct($scheduledTaskRepository, $logger);
         $this->orderRepository = $orderRepository;
         $this->loyaltyEngageApiService = $loyaltyEngageApiService;
         $this->logger = $logger;
@@ -62,7 +62,7 @@ class OrderPlaceTaskHandler extends ScheduledTaskHandler
     {
         $loyaltyOrderRetrieveLimit = $this->loyaltyEngageApiService->getLoyaltyOrderRetrieveLimit();
         $context = Context::createDefaultContext();
-        
+
         $criteria = new Criteria();
         $criteria->addFilter(new EqualsFilter('customFields.loyalty_order_place', false));
         $criteria->addFilter(new RangeFilter('customFields.loyalty_order_place_retrieve', [
@@ -104,7 +104,7 @@ class OrderPlaceTaskHandler extends ScheduledTaskHandler
             $response = $this->loyaltyEngageApiService->placeOrder($email, $orderNumber, $products);
 
             $customFields = $order->getCustomFields() ?? [];
-            
+
             if ($response && $response == 200) {
                 $customFields['loyalty_order_place'] = true;
             } else {


### PR DESCRIPTION
The `$exceptionLogger`argument for the `Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler` class was optional for Shopware 6.5, but needs to be explicitly provided since version 6.7 (see https://github.com/shopware/core/blob/v6.5.8.18/Framework/MessageQueue/ScheduledTask/ScheduledTaskHandler.php#L21-L23). This pull request passes the logger object to the parent handler class.