### PR TITLE
Properly register message handlers

### DIFF
--- a/src/Resources/config/services.xml
+++ b/src/Resources/config/services.xml
@@ -180,6 +180,7 @@
         </service>
 
         <service id="LoyaltyEngage\Scheduled\CartExpiryTaskHandler">
+            <tag name="messenger.message_handler" />
             <argument type="service" id="scheduled_task.repository" />
             <argument type="service" id="order.repository" />
             <argument type="service" id="LoyaltyEngage\Service\LoyaltyEngageApiService" />
@@ -191,6 +192,7 @@
         </service>
 
         <service id="LoyaltyEngage\Scheduled\OrderPlaceTaskHandler">
+            <tag name="messenger.message_handler" />
             <argument type="service" id="scheduled_task.repository" />
             <argument type="service" id="order.repository" />
             <argument type="service" id="LoyaltyEngage\Service\LoyaltyEngageApiService" />

--- a/src/Scheduled/CartExpiryTaskHandler.php
+++ b/src/Scheduled/CartExpiryTaskHandler.php
@@ -12,7 +12,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\NotFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
+#[AsMessageHandler(handles: CartExpiryTask::class)]
 class CartExpiryTaskHandler extends ScheduledTaskHandler
 {
     /**

--- a/src/Scheduled/OrderPlaceTaskHandler.php
+++ b/src/Scheduled/OrderPlaceTaskHandler.php
@@ -11,7 +11,9 @@ use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\EqualsFilter;
 use Shopware\Core\Framework\DataAbstractionLayer\Search\Filter\RangeFilter;
 use Shopware\Core\Framework\MessageQueue\ScheduledTask\ScheduledTaskHandler;
 use Psr\Log\LoggerInterface;
+use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 
+#[AsMessageHandler(handles: OrderPlaceTask::class)]
 class OrderPlaceTaskHandler extends ScheduledTaskHandler
 {
     /**


### PR DESCRIPTION
This PR registers the `CartExpiryTaskHandler` and `OrderPlaceTaskHandler` classes as handlers for their respective message classes. This fixes the following error;

```
Error thrown while handling message LoyaltyEngage\Scheduled\CartExpiryTask. Removing from transport after 0 retries. Error: "No handler for message "LoyaltyEngage\Scheduled\CartExpiryTask"." 
```
