### PR TITLE
Bugfix/invalid fields in criteria

### DIFF
--- a/src/Scheduled/CartExpiryTaskHandler.php
+++ b/src/Scheduled/CartExpiryTaskHandler.php
@@ -78,7 +78,6 @@ class CartExpiryTaskHandler extends ScheduledTaskHandler
         $criteria->addFilter(new NotFilter(NotFilter::CONNECTION_AND, [
             new EqualsFilter('customerId', null),
         ]));
-        $criteria->addFilter(new EqualsFilter('active', true));
         $criteria->addAssociation('customer');
 
         $carts = $this->orderRepository->search($criteria, $context);

--- a/src/Scheduled/CartExpiryTaskHandler.php
+++ b/src/Scheduled/CartExpiryTaskHandler.php
@@ -75,10 +75,10 @@ class CartExpiryTaskHandler extends ScheduledTaskHandler
         $criteria->addFilter(new RangeFilter('createdAt', [
             RangeFilter::LTE => $fromDate,
         ]));
+        $criteria->addAssociation('orderCustomer.customer');
         $criteria->addFilter(new NotFilter(NotFilter::CONNECTION_AND, [
-            new EqualsFilter('customerId', null),
+            new EqualsFilter('orderCustomer.customerId', null),
         ]));
-        $criteria->addAssociation('customer');
 
         $carts = $this->orderRepository->search($criteria, $context);
 


### PR DESCRIPTION
This PR fixes the following errors, which would appear after merging https://github.com/Loyalty-Engage/loyalty-engage-shopware/pull/3:

```
Error thrown while handling message LoyaltyEngage\Scheduled\CartExpiryTask. Removing from transport after 0 retries. Error: "Handling "LoyaltyEngage\Scheduled\CartExpiryTask" failed: Field "customerId" in entity "order" was not found." 
```
And
```
Error thrown while handling message LoyaltyEngage\Scheduled\CartExpiryTask. Removing from transport after 0 retries. Error: "Handling "LoyaltyEngage\Scheduled\CartExpiryTask" failed: Field "active" in entity "order" was not found."
```

The order entity does not have a `customerId` field (see https://shopware.stoplight.io/docs/admin-api/991f88e90b0d6-order), instead the customer ID is associated to an order by the `orderCustomer` entity (see https://shopware.stoplight.io/docs/admin-api/d12f674ee0270-order-customer).

Also, the order entity does not have an `active` property. The property shown on https://shopware.stoplight.io/docs/admin-api/991f88e90b0d6-order is part of the `language` entity. 